### PR TITLE
Add guard clause

### DIFF
--- a/etc/bashrc.d/app-config.bash
+++ b/etc/bashrc.d/app-config.bash
@@ -15,7 +15,8 @@
 
 # Initialize the Python version manager
 
-    if which -s pyenv; then
+    # If pyenv is installed and hasn't been initialized yet.
+    if which -s pyenv && [[ -z "${PYENV_SHELL}" ]]; then
       export PYENV_VIRTUALENV_DISABLE_PROMPT=1
       eval "$(pyenv init -)"
     fi
@@ -23,7 +24,8 @@
 
 # Initialize the Ruby Version manager
 
-    if which -s rbenv; then
+    # If rbenv is installed and hasn't been initialized yet.
+    if which -s rbenv && [[ -z "${RBENV_SHELL}" ]]; then
       eval "$(rbenv init -)"
     fi
 

--- a/etc/bashrc.d/exports.bash
+++ b/etc/bashrc.d/exports.bash
@@ -33,10 +33,22 @@
   # 3. Enable the path that replicates the environment that has previously been used
   # 5. Profit
 
+    function exists_in_path () {
+      target=$1
+      echo -e ${PATH//:/\\n} | egrep "^${target}$" &>/dev/null
+      return $?
+    }
+
     NODE_MODULES_BIN=$HOME/node_modules/.bin
     PERSONAL_BIN=$HOME/.local/bin
-    [[ -z $(/usr/bin/which -s node) ]] && [[ -d $NODE_MODULES_BIN ]] && PATH=$NODE_MODULES_BIN:$PATH
-    [[ -d $PERSONAL_BIN ]] && PATH=$PERSONAL_BIN:$PATH
+    # XXX: This -z isn't working how you intended.  You meant to be checking if the return code was zero.
+    #[[ -z $(/usr/bin/which -s node) ]] && [[ -d $NODE_MODULES_BIN ]] && PATH=$NODE_MODULES_BIN:$PATH
+    if ! exists_in_path $NODE_MODULES_BIN; then
+      [[ -d $NODE_MODULES_BIN ]] && PATH=$NODE_MODULES_BIN:$PATH
+    fi
+    if ! exists_in_path $PERSONAL_BIN; then
+      [[ -d $PERSONAL_BIN ]] && PATH=$PERSONAL_BIN:$PATH
+    fi
     export PATH
 
 

--- a/etc/bashrc.d/prompt.bash
+++ b/etc/bashrc.d/prompt.bash
@@ -195,7 +195,9 @@
 
     function set_prompt() {
       if ! type -t __git_ps1 >/dev/null; then
-        echo "Repairing missing __git_ps1"
+        # !!!: Leaving this in case I want to turn it on again, so I can see the 
+        # scenarios where this happens.
+        #echo "Repairing missing __git_ps1"
         local filepath_suffix=opt/git/etc/bash_completion.d/git-prompt.sh
         if [ -f /usr/local/$filepath_suffix ]; then
           . /usr/local/$filepath_suffix


### PR DESCRIPTION
Add logic to prevent path elements from being added if they already exist in the `$PATH`; for example, sub-shell or `poetry shell` type situations.